### PR TITLE
Add emission color to digital shader. 

### DIFF
--- a/assets/shaders/VTSDigitalClock.shader
+++ b/assets/shaders/VTSDigitalClock.shader
@@ -1,7 +1,7 @@
 ﻿Shader "VTS/DigitalClock" {
     Properties {
         _Color ("Color", Color) = (1,1,1,1)
-        _Emissive ("Emission", Color) = (0,0,0,1)
+        _EmissionColor ("Emission", Color) = (0,0,0,1)
         _TexChars ("Characters", 2D) = "white" {}
         _TexWP ("WebPanelRender", 2D) = "white" {}
         _Glossiness ("Smoothness", Range(0,1)) = 0.5
@@ -28,7 +28,7 @@
         half _Glossiness;
         half _Metallic;
         fixed4 _Color;
-        fixed4 _Emissive;
+        fixed4 _EmissionColor;
         float _Cutoff;
         int _IsPanorama;
 
@@ -66,7 +66,7 @@
             fixed4 c = tex2D(_TexChars, uv0);
             clip(c.a-_Cutoff);
             o.Albedo = c.rgb;
-            o.Emission = (_Emissive*((c.r + c.g + c.b)/3));
+            o.Emission = (_EmissionColor*((c.r + c.g + c.b)/3));
             o.Metallic = _Metallic;
             o.Smoothness = _Glossiness;
             const float clipThreshold = 0.01;


### PR DESCRIPTION
This adds an option for emission to the digital shader so that it shows up more clearly in dark worlds.

Example: https://cdn.discordapp.com/attachments/453927022520172574/506204316059566090/VRChat_1920x1080_2018-10-28_15-34-22.364.png